### PR TITLE
Temporarily disable doctest as an upstream config issue causes cabal failure

### DIFF
--- a/composable-associations-aeson/composable-associations-aeson.cabal
+++ b/composable-associations-aeson/composable-associations-aeson.cabal
@@ -38,15 +38,15 @@ test-suite tests
                , tasty-hunit
                , bytestring
 
-test-suite doctest
-  type:              exitcode-stdio-1.0
-  hs-source-dirs:    doctest
-  main-is:           Main.hs
-  build-depends:     base >= 4.7 && < 5
-                   , composable-associations-aeson
-                   , doctest >= 0.9.12
-                   , bytestring
-  default-language:  Haskell2010
+--test-suite doctest
+--  type:              exitcode-stdio-1.0
+--  hs-source-dirs:    doctest
+--  main-is:           Main.hs
+--  build-depends:     base >= 4.7 && < 5
+--                   , composable-associations-aeson
+--                   , doctest >= 0.9.12
+--                   , bytestring
+--  default-language:  Haskell2010
 
 source-repository head
   type:     git


### PR DESCRIPTION
https://github.com/sol/doctest/issues/169